### PR TITLE
Fix committee size selector update when adding a candidate

### DIFF
--- a/js/InstanceManagement.js
+++ b/js/InstanceManagement.js
@@ -19,6 +19,7 @@ export function addCandidate() {
         state.u[newCandidate][i] = 0;
     }
     document.getElementById('committee-size-input').max = state.C.length - 1;
+    document.getElementById('committee-size-range').max = state.C.length - 1;
     buildTable();
 }
 

--- a/js/abcvoting.js
+++ b/js/abcvoting.js
@@ -50,6 +50,9 @@ document.addEventListener('DOMContentLoaded', function () {
         el.disabled = true;
     });
 
+    document.getElementById("committee-size-input").max = state.C.length - 1;
+    document.getElementById("committee-size-range").max = state.C.length - 1;
+
     document.getElementById("committee-size-input").addEventListener('input', function () {
         setCommitteeSize(parseInt(document.getElementById("committee-size-input").value));
         buildTable();


### PR DESCRIPTION
Fixes #5

Update the committee size selector to allow values up to m-1 when adding a candidate.

* Update the `addCandidate` function in `js/InstanceManagement.js` to set the maximum value of the committee size input and range to `state.C.length - 1`.
* Update the `DOMContentLoaded` event listener in `js/abcvoting.js` to set the initial maximum value of the committee size input and range to `state.C.length - 1`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DominikPeters/abcvoting-app/pull/6?shareId=374a938f-3b07-4d16-a9e1-472b85317590).